### PR TITLE
feat(config.ini): kimi support auto

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -40,11 +40,11 @@ remote_api_key = "${YOUR-API-KEY}"
 # use 128000 for kimi, 192000 for gpt/xi-api, 16000 for deepseek, 128000 for zhipuai
 remote_llm_max_text_length = 128000
 # openai API model type, support model list:
-# "moonshot-v1-128k" for kimi,
+# "auto" for kimi. To save money, we auto select model name by prompt length.
 # "gpt-4-0613" for gpt/xi-api,
 # "deepseek-chat" for deepseek,
 # "glm-4" for zhipuai,
-remote_llm_model = "moonshot-v1-128k"
+remote_llm_model = "auto"
 # request per minute
 rpm = 500
 

--- a/huixiangdou/service/llm_server_hybrid.py
+++ b/huixiangdou/service/llm_server_hybrid.py
@@ -281,8 +281,21 @@ class HybridLLMServer:
                                   system=SYSTEM)
 
         logger.debug('remote api sending: {}'.format(messages))
+
+        model = 'moonshot-v1-8k'
+        prompt_len = len(prompt)
+        if prompt_len <= int(8192 * 1.5) - 1024:
+            model = 'moonshot-v1-8k'
+        elif prompt_len <= int(32768 * 1.5) - 1024:
+            model = 'moonshot-v1-32k'
+        else:
+            prompt = prompt[0: int(128000 * 1.5) -1024]
+            model = 'moonshot-v1-128k'
+
+        logger.info('choose kimi model {}'.format(model))
+
         completion = client.chat.completions.create(
-            model=self.server_config['remote_llm_model'],
+            model=model,
             messages=messages,
             temperature=0.0,
         )

--- a/huixiangdou/service/llm_server_hybrid.py
+++ b/huixiangdou/service/llm_server_hybrid.py
@@ -282,15 +282,17 @@ class HybridLLMServer:
 
         logger.debug('remote api sending: {}'.format(messages))
 
-        model = 'moonshot-v1-8k'
-        prompt_len = len(prompt)
-        if prompt_len <= int(8192 * 1.5) - 1024:
-            model = 'moonshot-v1-8k'
-        elif prompt_len <= int(32768 * 1.5) - 1024:
-            model = 'moonshot-v1-32k'
-        else:
-            prompt = prompt[0: int(128000 * 1.5) -1024]
-            model = 'moonshot-v1-128k'
+        model = self.server_config['remote_llm_model']
+
+        if model == 'auto':
+            prompt_len = len(prompt)
+            if prompt_len <= int(8192 * 1.5) - 1024:
+                model = 'moonshot-v1-8k'
+            elif prompt_len <= int(32768 * 1.5) - 1024:
+                model = 'moonshot-v1-32k'
+            else:
+                prompt = prompt[0: int(128000 * 1.5) -1024]
+                model = 'moonshot-v1-128k'
 
         logger.info('choose kimi model {}'.format(model))
 


### PR DESCRIPTION
If model name use `auto`, `llm_server_hybrid.py` would auto select model by prompt lenght.