### PR TITLE
feat: add MiniMax as LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ The Web version's API for Android also supports other devices. See [Python sampl
 - [StepFun](https://platform.stepfun.com)
 - [vLLM](https://github.com/vllm-project/vllm)
 - [Silicon🏷️](https://cloud.siliconflow.cn/s/tpoisonooo)
-- [PPIO🏷️](https://ppinfra.com/user/register?invited_by=7GF8QS) 
+- [PPIO🏷️](https://ppinfra.com/user/register?invited_by=7GF8QS)
 - [Xi-Api](https://api.xi-ai.cn)
+- [MiniMax](https://platform.minimaxi.com)
 
 </td>
 <td>
@@ -253,6 +254,10 @@ remote_llm_model = "auto"
 # remote_type = "ppio"
 # remote_api_key = "sk-xxxxxxxxxxxxx"
 # remote_llm_model = "thudm/glm-4-9b-chat"
+
+# remote_type = "minimax"
+# remote_api_key = "sk-xxxxxxxxxxxxx"
+# remote_llm_model = "MiniMax-M1"
 ```
 
 Then run the test:

--- a/README_zh.md
+++ b/README_zh.md
@@ -115,9 +115,9 @@ Web 版给 android 的接口，也支持非 android 调用，见[python 样例�
 - [StepFun](https://platform.stepfun.com)
 - [vLLM](https://github.com/vllm-project/vllm)
 - [Silicon🏷️](https://cloud.siliconflow.cn/s/tpoisonooo)
-- [PPIO🏷️](https://ppinfra.com/user/register?invited_by=7GF8QS) 
+- [PPIO🏷️](https://ppinfra.com/user/register?invited_by=7GF8QS)
 - [Xi-Api](https://api.xi-ai.cn)
-
+- [MiniMax](https://platform.minimaxi.com)
 
 </td>
 <td>
@@ -250,6 +250,10 @@ remote_llm_model = "auto"
 # remote_type = "ppio"
 # remote_api_key = "sk-xxxxxxxxxxxxx"
 # remote_llm_model = "thudm/glm-4-9b-chat"
+
+# remote_type = "minimax"
+# remote_api_key = "sk-xxxxxxxxxxxxx"
+# remote_llm_model = "MiniMax-M1"
 ```
 
 然后运行测试：

--- a/config.ini
+++ b/config.ini
@@ -32,7 +32,7 @@ save_dir = "logs/web_search_result"
 [llm]
 [llm.server]
 # remote LLM service configuration
-# support "gpt", "kimi", "deepseek", "zhipuai", "step", "internlm", "xi-api", "vllm", "siliconcloud" and "ppio"
+# support "gpt", "kimi", "deepseek", "zhipuai", "step", "internlm", "xi-api", "vllm", "siliconcloud", "ppio" and "minimax"
 # support "siliconcloud", see https://siliconflow.cn/zh-cn/siliconcloud
 # xi-api and alles-apin is chinese gpt proxy
 # for internlm, see https://internlm.intern-ai.org.cn/api/document
@@ -40,7 +40,7 @@ save_dir = "logs/web_search_result"
 remote_type = "kimi"
 remote_api_key = "sk_XXXXXXXXXXXXXXXXXXXXXx"
 # max token length for LLM input.
-# use 128000 for kimi, 192000 for gpt/xi-api, 16000 for deepseek, 128000 for zhipuai, 32000 for others.
+# use 128000 for kimi, 192000 for gpt/xi-api, 16000 for deepseek, 128000 for zhipuai, 1000000 for minimax, 32000 for others.
 remote_llm_max_text_length = 32000
 # openai API model type, support model list:
 # "auto" or "kimi-k2-0711-preview" for kimi. To save money, we auto select model name by prompt length.
@@ -54,6 +54,7 @@ remote_llm_max_text_length = 32000
 # for example "alibaba/Qwen1.5-110B-Chat", see https://siliconflow.readme.io/reference/chat-completions-1
 # ppio
 # for example "thudm/glm-4-9b-chat", see https://ppinfra.com/model-api/console
+# "MiniMax-M1" or "auto" for minimax, see https://platform.minimaxi.com
 remote_llm_model = "kimi-k2-0711-preview"
 # request per minute
 rpm = 500

--- a/huixiangdou/services/llm.py
+++ b/huixiangdou/services/llm.py
@@ -28,7 +28,8 @@ backend2url = {
     'local': 'http://localhost:8000/v1',
     'vllm': 'http://localhost:8000/v1',
     'ppio': 'https://api.ppinfra.com/v3/openai',
-    'internlm': 'https://chat.intern-ai.org.cn/api/v1'
+    'internlm': 'https://chat.intern-ai.org.cn/api/v1',
+    'minimax': 'https://api.minimax.io/v1'
 }
 
 backend2model = {
@@ -37,7 +38,8 @@ backend2model = {
     "deepseek": "deepseek-chat",
     "zhipuai": "glm-4",
     "siliconcloud": "Qwen/Qwen2.5-14B-Instruct",
-    "ppio": "thudm/glm-4-9b-chat"
+    "ppio": "thudm/glm-4-9b-chat",
+    "minimax": "MiniMax-M1"
 }
 
 def limit_async_func_call(max_size: int, waitting_time: float = 0.1):
@@ -125,6 +127,13 @@ class LLM:
                 model = 'step-1-256k'
             else:
                 raise ValueError('Input token length exceeds 256k')
+        elif backend.name == 'minimax' and model == 'auto':
+            if token_size <= 204000 - response_reserve_length:
+                model = 'MiniMax-M1'
+            elif token_size <= 1000000 - response_reserve_length:
+                model = 'MiniMax-M1'
+            else:
+                raise ValueError('Input token length exceeds 1M')
         elif not model and backend.name in backend2model:
             model = backend2model[backend.name]
         return model

--- a/tests/test_minimax.py
+++ b/tests/test_minimax.py
@@ -1,0 +1,33 @@
+# python3
+# Test MiniMax LLM API via OpenAI-compatible interface
+# Usage: MINIMAX_API_KEY=your_key python3 tests/test_minimax.py
+import os
+from openai import OpenAI
+
+api_key = os.environ.get('MINIMAX_API_KEY', '')
+if not api_key:
+    print('Please set MINIMAX_API_KEY environment variable')
+    exit(1)
+
+client = OpenAI(api_key=api_key, base_url='https://api.minimax.io/v1')
+queries = [
+    'What is the full name of ncnn, given that cnn stands for Convolutional Neural Network and n is for nihui, the author of ncnn?',
+    '"How to install mmdeploy?"\nPlease read the above carefully and determine if it is a question with a clear topic. Rate it from 0 to 10. Provide only the score without explanation.\nCriteria: 10 points for a question with subject, verb, and object; deduct for missing components; 0 for declarative sentences or non-questions.',
+]
+
+for query in queries:
+    response = client.chat.completions.create(
+        model='MiniMax-M1',
+        messages=[
+            {
+                'role': 'system',
+                'content': 'You are a helpful assistant'
+            },
+            {
+                'role': 'user',
+                'content': query
+            },
+        ],
+        temperature=0.7)
+
+    print(response.choices[0].message.content)

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,114 @@
+"""Integration tests for MiniMax LLM provider.
+
+These tests make real API calls to the MiniMax API.
+They require MINIMAX_API_KEY to be set in the environment.
+
+Run with: MINIMAX_API_KEY=your_key pytest tests/test_minimax_integration.py -v
+"""
+import os
+import sys
+import tempfile
+import pytest
+import asyncio
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+MINIMAX_API_KEY = os.environ.get('MINIMAX_API_KEY', '')
+skip_no_key = pytest.mark.skipif(
+    not MINIMAX_API_KEY,
+    reason='MINIMAX_API_KEY not set'
+)
+
+
+@skip_no_key
+class TestMiniMaxLLMIntegration:
+    """Integration tests using real MiniMax API."""
+
+    def _make_config(self, model='MiniMax-M1'):
+        config_content = f"""
+[llm]
+[llm.server]
+remote_type = "minimax"
+remote_api_key = "{MINIMAX_API_KEY}"
+remote_llm_max_text_length = 1000000
+remote_llm_model = "{model}"
+rpm = 500
+tpm = 200000
+"""
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False)
+        f.write(config_content)
+        f.flush()
+        f.close()
+        return f.name
+
+    def test_chat_basic(self):
+        """Test basic chat completion with MiniMax."""
+        from huixiangdou.services.llm import LLM
+        config_path = self._make_config()
+        try:
+            llm = LLM(config_path=config_path)
+            result = asyncio.get_event_loop().run_until_complete(
+                llm.chat(
+                    prompt='What is 2+2? Reply with just the number.',
+                    system_prompt='You are a helpful assistant. Be concise.',
+                    max_tokens=1024,
+                    timeout=60
+                )
+            )
+            assert result is not None
+            assert len(result) > 0
+        finally:
+            os.unlink(config_path)
+
+    def test_chat_stream(self):
+        """Test streaming chat completion with MiniMax."""
+        from huixiangdou.services.llm import LLM
+        config_path = self._make_config()
+        try:
+            llm = LLM(config_path=config_path)
+
+            async def collect_stream():
+                chunks = []
+                async for chunk in llm.chat_stream(
+                    prompt='Say hello.',
+                    system_prompt='You are a helpful assistant. Be concise.',
+                    max_tokens=1024,
+                    timeout=60
+                ):
+                    chunks.append(chunk)
+                return ''.join(chunks)
+
+            result = asyncio.get_event_loop().run_until_complete(collect_stream())
+            assert result is not None
+            assert len(result) > 0
+        finally:
+            os.unlink(config_path)
+
+    def test_chat_with_history(self):
+        """Test chat with conversation history."""
+        from huixiangdou.services.llm import LLM
+        config_path = self._make_config()
+        try:
+            llm = LLM(config_path=config_path)
+            history = [
+                {'role': 'user', 'content': 'My name is Alice.'},
+                {'role': 'assistant', 'content': 'Hello Alice! Nice to meet you.'},
+            ]
+            result = asyncio.get_event_loop().run_until_complete(
+                llm.chat(
+                    prompt='What is my name? Reply in one word.',
+                    system_prompt='You are a helpful assistant. Be concise.',
+                    history=history,
+                    max_tokens=1024,
+                    timeout=60
+                )
+            )
+            assert result is not None
+            assert len(result) > 0
+            assert 'Alice' in result
+        finally:
+            os.unlink(config_path)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/test_minimax_unit.py
+++ b/tests/test_minimax_unit.py
@@ -1,0 +1,260 @@
+"""Unit tests for MiniMax LLM provider integration."""
+import os
+import sys
+import json
+import tempfile
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from huixiangdou.services.llm import backend2url, backend2model, Backend, LLM
+
+
+class TestMiniMaxBackendRegistry:
+    """Tests for MiniMax entries in backend registries."""
+
+    def test_minimax_url_registered(self):
+        """MiniMax base URL should be in backend2url."""
+        assert 'minimax' in backend2url
+        assert backend2url['minimax'] == 'https://api.minimax.io/v1'
+
+    def test_minimax_default_model_registered(self):
+        """MiniMax default model should be in backend2model."""
+        assert 'minimax' in backend2model
+        assert backend2model['minimax'] == 'MiniMax-M1'
+
+    def test_backend2url_has_all_providers(self):
+        """All documented providers should be in backend2url."""
+        expected = ['kimi', 'step', 'xi-api', 'deepseek', 'zhipuai',
+                    'siliconcloud', 'local', 'vllm', 'ppio', 'internlm', 'minimax']
+        for provider in expected:
+            assert provider in backend2url, f'{provider} missing from backend2url'
+
+
+class TestMiniMaxBackendInit:
+    """Tests for Backend class with MiniMax config."""
+
+    def test_backend_minimax_auto_url(self):
+        """Backend should auto-resolve MiniMax base URL."""
+        data = {
+            'remote_api_key': 'test-key',
+            'remote_type': 'minimax',
+            'remote_llm_max_text_length': 1000000,
+            'remote_llm_model': 'MiniMax-M1',
+        }
+        backend = Backend(name='minimax', data=data)
+        assert backend.base_url == 'https://api.minimax.io/v1'
+        assert backend.api_key == 'test-key'
+        assert backend.model == 'MiniMax-M1'
+
+    def test_backend_minimax_custom_url(self):
+        """Backend should use custom base_url if provided."""
+        data = {
+            'remote_api_key': 'test-key',
+            'remote_type': 'minimax',
+            'remote_llm_max_text_length': 32000,
+            'remote_llm_model': 'MiniMax-M1',
+            'base_url': 'https://custom.proxy.com/v1',
+        }
+        backend = Backend(name='minimax', data=data)
+        assert backend.base_url == 'https://custom.proxy.com/v1'
+
+    def test_backend_minimax_max_token_calculation(self):
+        """Backend should calculate max_token_size correctly."""
+        data = {
+            'remote_api_key': 'test-key',
+            'remote_type': 'minimax',
+            'remote_llm_max_text_length': 1000000,
+            'remote_llm_model': 'MiniMax-M1',
+        }
+        backend = Backend(name='minimax', data=data)
+        assert backend.max_token_size == 1000000 - 4096
+
+    def test_backend_minimax_default_rpm_tpm(self):
+        """Backend should use default RPM/TPM if not specified."""
+        data = {
+            'remote_api_key': 'test-key',
+            'remote_type': 'minimax',
+            'remote_llm_max_text_length': 32000,
+            'remote_llm_model': 'MiniMax-M1',
+        }
+        backend = Backend(name='minimax', data=data)
+        assert backend.rpm is not None
+        assert backend.tpm is not None
+
+    def test_backend_minimax_custom_rpm_tpm(self):
+        """Backend should accept custom RPM/TPM."""
+        data = {
+            'remote_api_key': 'test-key',
+            'remote_type': 'minimax',
+            'remote_llm_max_text_length': 32000,
+            'remote_llm_model': 'MiniMax-M1',
+            'rpm': 100,
+            'tpm': 80000,
+        }
+        backend = Backend(name='minimax', data=data)
+        # RPM/TPM are wrappers, just check they were created
+        assert backend.rpm is not None
+        assert backend.tpm is not None
+
+    def test_backend_minimax_jsonify(self):
+        """Backend jsonify should return expected format."""
+        data = {
+            'remote_api_key': 'test-key',
+            'remote_type': 'minimax',
+            'remote_llm_max_text_length': 32000,
+            'remote_llm_model': 'MiniMax-M1',
+        }
+        backend = Backend(name='minimax', data=data)
+        result = backend.jsonify()
+        assert result['api_key'] == 'minimax'
+        assert result['model'] == 'MiniMax-M1'
+
+
+class TestMiniMaxModelSelection:
+    """Tests for choose_model() with MiniMax backend."""
+
+    def _make_llm_with_minimax(self, model='auto'):
+        """Helper to create LLM instance with MiniMax config."""
+        config_content = f"""
+[llm]
+[llm.server]
+remote_type = "minimax"
+remote_api_key = "test-key"
+remote_llm_max_text_length = 1000000
+remote_llm_model = "{model}"
+rpm = 500
+tpm = 200000
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write(config_content)
+            f.flush()
+            try:
+                llm = LLM(config_path=f.name)
+                return llm
+            finally:
+                os.unlink(f.name)
+
+    def test_choose_model_auto_small_input(self):
+        """Auto mode should select MiniMax-M1 for small input."""
+        llm = self._make_llm_with_minimax(model='auto')
+        backend = llm.backends['minimax']
+        model = llm.choose_model(backend, token_size=1000)
+        assert model == 'MiniMax-M1'
+
+    def test_choose_model_auto_medium_input(self):
+        """Auto mode should select MiniMax-M1 for medium input."""
+        llm = self._make_llm_with_minimax(model='auto')
+        backend = llm.backends['minimax']
+        model = llm.choose_model(backend, token_size=100000)
+        assert model == 'MiniMax-M1'
+
+    def test_choose_model_auto_large_input(self):
+        """Auto mode should select MiniMax-M1 for large input within 1M."""
+        llm = self._make_llm_with_minimax(model='auto')
+        backend = llm.backends['minimax']
+        model = llm.choose_model(backend, token_size=500000)
+        assert model == 'MiniMax-M1'
+
+    def test_choose_model_auto_exceeds_limit(self):
+        """Auto mode should raise ValueError when input exceeds 1M."""
+        llm = self._make_llm_with_minimax(model='auto')
+        backend = llm.backends['minimax']
+        with pytest.raises(ValueError, match='1M'):
+            llm.choose_model(backend, token_size=1000001)
+
+    def test_choose_model_explicit(self):
+        """Explicit model name should be used as-is."""
+        llm = self._make_llm_with_minimax(model='MiniMax-M1')
+        backend = llm.backends['minimax']
+        model = llm.choose_model(backend, token_size=5000)
+        assert model == 'MiniMax-M1'
+
+    def test_choose_model_empty_uses_default(self):
+        """Empty model should fall back to backend2model default."""
+        llm = self._make_llm_with_minimax(model='')
+        backend = llm.backends['minimax']
+        # Empty model but not 'auto', falls to backend2model lookup
+        model = llm.choose_model(backend, token_size=5000)
+        assert model == 'MiniMax-M1'
+
+
+class TestMiniMaxLLMInit:
+    """Tests for LLM initialization with MiniMax config."""
+
+    def test_llm_init_minimax(self):
+        """LLM should initialize correctly with MiniMax config."""
+        config_content = """
+[llm]
+[llm.server]
+remote_type = "minimax"
+remote_api_key = "test-api-key"
+remote_llm_max_text_length = 1000000
+remote_llm_model = "MiniMax-M1"
+rpm = 500
+tpm = 200000
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write(config_content)
+            f.flush()
+            try:
+                llm = LLM(config_path=f.name)
+                assert 'minimax' in llm.backends
+                assert llm.backends['minimax'].base_url == 'https://api.minimax.io/v1'
+                assert llm.backends['minimax'].model == 'MiniMax-M1'
+            finally:
+                os.unlink(f.name)
+
+    def test_llm_default_model_info_minimax(self):
+        """default_model_info should return MiniMax info."""
+        config_content = """
+[llm]
+[llm.server]
+remote_type = "minimax"
+remote_api_key = "test-api-key"
+remote_llm_max_text_length = 32000
+remote_llm_model = "MiniMax-M1"
+rpm = 500
+tpm = 200000
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write(config_content)
+            f.flush()
+            try:
+                llm = LLM(config_path=f.name)
+                info = llm.default_model_info()
+                assert info['api_key'] == 'minimax'
+                assert info['model'] == 'MiniMax-M1'
+            finally:
+                os.unlink(f.name)
+
+
+class TestMiniMaxConfigFiles:
+    """Tests for MiniMax references in config files."""
+
+    def test_config_ini_mentions_minimax(self):
+        """config.ini should document MiniMax as supported provider."""
+        config_path = os.path.join(os.path.dirname(__file__), '..', 'config.ini')
+        with open(config_path) as f:
+            content = f.read()
+        assert 'minimax' in content.lower()
+
+    def test_readme_mentions_minimax(self):
+        """README.md should list MiniMax as supported LLM."""
+        readme_path = os.path.join(os.path.dirname(__file__), '..', 'README.md')
+        with open(readme_path) as f:
+            content = f.read()
+        assert 'MiniMax' in content
+
+    def test_readme_zh_mentions_minimax(self):
+        """README_zh.md should list MiniMax as supported LLM."""
+        readme_path = os.path.join(os.path.dirname(__file__), '..', 'README_zh.md')
+        with open(readme_path) as f:
+            content = f.read()
+        assert 'MiniMax' in content
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com) as a supported LLM backend via its OpenAI-compatible API.

- Register MiniMax in `backend2url` and `backend2model` with `https://api.minimax.io/v1`
- Add auto model selection for `MiniMax-M1` (supports up to 1M context window)
- Update `config.ini` with MiniMax documentation and model examples
- Add MiniMax to the LLM support table in both `README.md` and `README_zh.md`
- Add config example in setup instructions for both READMEs
- Add `tests/test_minimax.py` demo script, 20 unit tests, and 3 integration tests

## Configuration Example

```ini
[llm.server]
remote_type = "minimax"
remote_api_key = "sk-xxxxxxxxxxxxx"
remote_llm_model = "MiniMax-M1"
remote_llm_max_text_length = 1000000
```

## Test Plan

- [x] 20 unit tests passing (`pytest tests/test_minimax_unit.py -v`)
- [x] 3 integration tests passing with real MiniMax API (`pytest tests/test_minimax_integration.py -v`)
- [ ] Verify `remote_type = "minimax"` works end-to-end with `python3 -m huixiangdou.main`

## Files Changed (7 files, ~433 additions)

| File | Change |
|------|--------|
| `huixiangdou/services/llm.py` | Add minimax to backend2url, backend2model, choose_model() |
| `config.ini` | Document minimax as supported provider |
| `README.md` | Add MiniMax to LLM support table + config example |
| `README_zh.md` | Add MiniMax to LLM support table + config example |
| `tests/test_minimax.py` | Demo script for MiniMax API |
| `tests/test_minimax_unit.py` | 20 unit tests |
| `tests/test_minimax_integration.py` | 3 integration tests |